### PR TITLE
fix for double subtraction of commission amount

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "banana-vault"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 authors = ["Banana DAO"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "banana-vault"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["Banana DAO"]
 

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -6,8 +6,8 @@ use crate::{
     },
     state::{
         Config, ACCOUNTS_PENDING_ACTIVATION, ADDRESSES_WAITING_FOR_EXIT, ASSETS_PENDING_ACTIVATION,
-        CAP_REACHED, COMMISSION_REWARDS, CONFIG, HALT_EXITS_AND_JOINS, JOIN_TIME, LAST_UPDATE,
-        POSITION_OPEN, UNCOMPOUNDED_REWARDS, VAULT_RATIO, VAULT_TERMINATED, WHITELISTED_DEPOSITORS,
+        CAP_REACHED, COMMISSION_REWARDS, CONFIG, HALT_EXITS_AND_JOINS, LAST_UPDATE, POSITION_OPEN,
+        UNCOMPOUNDED_REWARDS, VAULT_RATIO, VAULT_TERMINATED, WHITELISTED_DEPOSITORS,
     },
 };
 use cosmwasm_std::{
@@ -38,7 +38,7 @@ const CONTRACT_NAME: &str = env!("CARGO_PKG_NAME");
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 // incompatible versions, which should not be migrated from
-const INCOMPATIBLE_TAGS: [&str; 2] = ["0.1.0", "0.2.0"];
+const INCOMPATIBLE_TAGS: [&str; 3] = ["0.1.0", "0.2.0", "0.3.0"];
 
 const PYTH_TESTNET_CONTRACT_ADDRESS: &str =
     "osmo1hpdzqku55lmfmptpyj6wdlugqs5etr6teqf7r4yqjjrxjznjhtuqqu5kdh";
@@ -1060,14 +1060,6 @@ pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> StdResult<Response
         ));
     }
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-
-    // convert JOIN_TIME to POSITION_OPEN then uninitialize it
-    if JOIN_TIME.load(deps.storage)? != 0 {
-        POSITION_OPEN.save(deps.storage, &true)?;
-    } else {
-        POSITION_OPEN.save(deps.storage, &false)?;
-    }
-    JOIN_TIME.remove(deps.storage);
 
     Ok(Response::default())
 }

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1239,18 +1239,20 @@ fn collect_rewards(
     let mut uncompounded_rewards: Coins =
         Coins::try_from(UNCOMPOUNDED_REWARDS.load(deps.storage)?).unwrap_or_default();
 
+    let commission_rate = config.commission.unwrap_or(Decimal::zero());
+
     for reward_coin in &reward_coins {
         let commission_amount = reward_coin
             .amount
-            .mul_floor(config.commission.unwrap_or(Decimal::zero()));
+            .mul_floor(commission_rate);
 
-        // compoundable rewards, minus commission
+        // compoundable rewards. add commission to the tracker
         if reward_coin.denom == config.asset0.denom {
             commission_coins[0].amount += commission_amount;
-            amount0 = reward_coin.amount.checked_sub(commission_amount)?;
+            amount0 = reward_coin.amount
         } else if reward_coin.denom == config.asset1.denom {
             commission_coins[1].amount += commission_amount;
-            amount1 = reward_coin.amount.checked_sub(commission_amount)?;
+            amount1 = reward_coin.amount
 
         // uncompounded rewards. commission will be deducted when the rewards are distributed
         } else {

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1234,6 +1234,8 @@ fn collect_rewards(
     let mut messages: Vec<CosmosMsg> = vec![];
     let mut attributes: Vec<Attribute> = vec![];
 
+    // if there's forfeited incentives in the response, min uptime for that incentive has yet not been met.
+    // can be overridden by the operator to allow forfeiture if repositioning is more advantageous
     if !position.forfeited_incentives.is_empty() && !override_uptime {
         return Err(ContractError::MinUptime());
     }

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -16,8 +16,6 @@ pub struct InstantiateMsg {
     pub pool_id: u64,
     // Seconds after which a price quote is rejected and joins/leaves can't be processed
     pub price_expiry: u64,
-    //  Uptime must be enforced to accurately calculate commission
-    pub min_uptime: Option<u64>,
     // CL Assets with their corresponding pyth price feed
     pub asset0: VaultAsset,
     pub asset1: VaultAsset,
@@ -72,12 +70,14 @@ pub enum ExecuteMsg {
         token_min_amount0: String,
         token_min_amount1: String,
         swap: Option<Swap>,
+        override_uptime: Option<bool>,
     },
     // Withdraw position
     WithdrawPosition {
         position_id: u64,
         liquidity_amount: String,
         update_users: Option<bool>,
+        override_uptime: Option<bool>,
     },
     // Process entries and exits (done internally by the contract every update frequency)
     ProcessNewEntriesAndExits {},
@@ -169,6 +169,7 @@ pub struct VaultParticipant {
 pub struct Status {
     pub join_time: u64,
     pub last_update: u64,
+    pub uptime_locked: bool,
     pub cap_reached: bool,
     pub halted: bool,
     pub closed: bool,

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -81,6 +81,8 @@ pub enum ExecuteMsg {
     },
     // Process entries and exits (done internally by the contract every update frequency)
     ProcessNewEntriesAndExits {},
+    // Claim collected commission
+    ClaimCommission {},
     // Join vault
     Join {},
     // Leave vault. If no address is specified, the sender will be removed. only the operator can remove other addresses

--- a/src/state.rs
+++ b/src/state.rs
@@ -21,6 +21,7 @@ pub enum TopKey {
     VaultTerminated = b'k',
     WhitelistedDepositors = b'l',
     JoinTime = b'm',
+    PositionOpen = b'n',
 }
 
 impl TopKey {
@@ -60,8 +61,10 @@ pub const CAP_REACHED: Item<bool> = Item::new(TopKey::CapReached.as_str());
 pub const VAULT_TERMINATED: Item<bool> = Item::new(TopKey::VaultTerminated.as_str());
 pub const WHITELISTED_DEPOSITORS: Map<Addr, Empty> =
     Map::new(TopKey::WhitelistedDepositors.as_str());
-// Time a position was last opened
+// Key maintained for backward compatibility
 pub const JOIN_TIME: Item<u64> = Item::new(TopKey::JoinTime.as_str());
+// Flag to indicate if the vault has an active position
+pub const POSITION_OPEN: Item<bool> = Item::new(TopKey::PositionOpen.as_str());
 
 #[cw_serde]
 pub struct Config {
@@ -71,7 +74,6 @@ pub struct Config {
     pub pool_id: u64,
     pub asset0: VaultAsset,
     pub asset1: VaultAsset,
-    pub min_uptime: Option<u64>,
     pub dollar_cap: Option<Uint128>,
     pub pyth_contract_address: Addr,
     pub price_expiry: u64,

--- a/src/state.rs
+++ b/src/state.rs
@@ -20,8 +20,7 @@ pub enum TopKey {
     CapReached = b'j',
     VaultTerminated = b'k',
     WhitelistedDepositors = b'l',
-    JoinTime = b'm',
-    PositionOpen = b'n',
+    PositionOpen = b'm',
 }
 
 impl TopKey {
@@ -61,8 +60,6 @@ pub const CAP_REACHED: Item<bool> = Item::new(TopKey::CapReached.as_str());
 pub const VAULT_TERMINATED: Item<bool> = Item::new(TopKey::VaultTerminated.as_str());
 pub const WHITELISTED_DEPOSITORS: Map<Addr, Empty> =
     Map::new(TopKey::WhitelistedDepositors.as_str());
-// Key maintained for backward compatibility
-pub const JOIN_TIME: Item<u64> = Item::new(TopKey::JoinTime.as_str());
 // Flag to indicate if the vault has an active position
 pub const POSITION_OPEN: Item<bool> = Item::new(TopKey::PositionOpen.as_str());
 

--- a/src/test_tube.rs
+++ b/src/test_tube.rs
@@ -214,7 +214,6 @@ fn setup_contract(asset1: VaultAsset) -> TestEnv {
                 image: None,
                 pool_id: 1,
                 price_expiry: 60,
-                min_uptime: None,
                 asset0: VaultAsset {
                     denom: "uosmo".to_string(),
                     price_identifier: PriceIdentifier::from_hex(
@@ -263,7 +262,6 @@ fn setup_contract(asset1: VaultAsset) -> TestEnv {
                     description: None,
                     image: None,
                     pool_id: 1,
-                    min_uptime: None,
                     asset0: VaultAsset {
                         denom: "uosmo".to_string(),
                         price_identifier: PriceIdentifier::from_hex(
@@ -445,6 +443,7 @@ fn withdraw_position(update: bool, test_env: &TestEnv, modules: &Modules) {
                 position_id: position.position_id,
                 liquidity_amount: position.liquidity,
                 update_users: Some(update),
+                override_uptime: None,
             },
             &[],
             &test_env.admin,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Improved the calculation and distribution of commissions and rewards within the contract functionality.
	- Adjusted logic in the `collect_rewards` function to use `commission_rate` from `config.commission`.
	- Added a new function `execute_claim_commission` for handling commission claiming and distribution.
	- Introduced a new enum variant `PositionOpen` and corresponding constant `POSITION_OPEN` for indicating active vault positions.
	- Removed the `min_uptime` field from the `Config` struct for simplification.
	- Updated the initialization of `VaultAsset` struct in the `setup_contract` function by removing the `min_uptime` field.
	- Added an `override_uptime` field in the `withdraw_position` function for flexibility.
- **New Features**
	- Added functionality to claim collected commission in the `ExecuteMsg` enum.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->